### PR TITLE
add GitHub actions to publish GitHub pages and add contributors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: deploy
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: build docc
+        run: |
+          chmod +x ./bin/publidh.sh
+          ./bin/publidh.sh
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: migration-guide
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: macos-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/update-contributor.yml
+++ b/.github/workflows/update-contributor.yml
@@ -1,0 +1,14 @@
+name: update-contributors
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update-contributors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: akhilmhdh/contributors-readme-action@v2.3.10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,9 @@ let package = Package(
         .executable(name: "swift5_examples", targets: ["Swift5Examples"]),
         .executable(name: "swift6_examples", targets: ["Swift6Examples"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
+    ],
     targets: [
         .target(
             name: "Library"

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [The Swift Concurrency Migration Guide][swift-migration-guide]の日本語訳リポジトリです。
 
-このリポジトリには、[Swift-DocC][docc] を使ってビルドされた The Swift Concurrency Migration Guide のソースが含まれています。
+このリポジトリには、[Swift-DocC][docc] を使ってビルドされたThe Swift Concurrency Migration Guideのソースが含まれています。
 
 ## コントリビューションについて
 
-The Swift Concurrency Migration Guide に貢献する方法については、[CONTRIBUTING.md][contributing]をご参照ください。
+The Swift Concurrency Migration Guideに貢献する方法については、[CONTRIBUTING.md][contributing]をご参照ください。
 
 ## ビルド方法
 
@@ -27,3 +27,8 @@ DocCを実行した後、`docc` が出力するリンクを開いて、ブラウ
 [contributing]: https://github.com/stzn/swift-migration-guide-jp/blob/main/CONTRIBUTING.md
 [docc]: https://github.com/apple/swift-docc
 [conduct]: https://www.swift.org/code-of-conduct
+
+# コントリビュータ
+
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -6,7 +6,7 @@ export DOCC_JSON_PRETTYPRINT="YES"
 
 output="./migration-guide"
 
-docc convert \
+(xcrun --find docc) convert \
     --experimental-enable-custom-templates \
     --hosting-base-path migration-guide \
     --output-path "$output" \


### PR DESCRIPTION
closes #11 

GitHub Actionsを追加しました。以下のことを行います。

- GitHub pagesにデプロイする 
- コントリビュータをREADME.mdに追加する (https://github.com/akhilmhdh/contributors-readme-action)