### PR TITLE
Support Custom Domain for DocC

### DIFF
--- a/deploy-docc-page.sh
+++ b/deploy-docc-page.sh
@@ -11,5 +11,4 @@ $DOCC_COMMAND convert Guide.docc \
 
 $DOCC_COMMAND process-archive transform-for-static-hosting \
   --output-path ./docs \
-  --hosting-base-path swift-migration-guide-jp \
   $DOCC_ARCHIVE


### PR DESCRIPTION
Remove `hosting-base-path` setting for the custom domain