### PR TITLE
update v3 -> v4

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -10,7 +10,7 @@ jobs:
   BuildDocCArchive:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build DocC Archive
         run: |
           ./deploy-docc-page.sh


### PR DESCRIPTION
@giginet san
すいませんもう一度お願いします🙏🏻

actions/upload-artifact@v3はもう使えないようです。
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/